### PR TITLE
fix: add ".cmd" suffix on windows

### DIFF
--- a/src/cliMode.ts
+++ b/src/cliMode.ts
@@ -1,3 +1,4 @@
+import { platform } from 'os'
 import ts from 'typescript'
 import type { UserConfig, ViteDevServer } from 'vite'
 import { exec, ChildProcess, spawn } from 'child_process'
@@ -27,7 +28,8 @@ function createTscProcess() {
       }
     },
     configureServer: (server: ViteDevServer) => {
-      const tsProc = exec('tsc --noEmit --watch', { cwd: server.config.root })
+      const checkerSuffix = platform() === 'win32' ? '.cmd' : ''
+      const tsProc = exec(`tsc${checkerSuffix} --noEmit --watch`, { cwd: server.config.root })
       // const tsProc = spawn('tsc', ['--noEmit', '--watch'], { cwd: root, stdio: 'pipe' })
       // diagnosticCount++
       tsProc.stdout!.on('data', (data) => {

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,4 +1,5 @@
 import { spawn } from 'child_process'
+import { platform } from 'os'
 import npmRunPath from 'npm-run-path'
 import { ConfigEnv, Plugin } from 'vite'
 import { PluginOptions } from './types'
@@ -35,7 +36,8 @@ export default function Plugin(userOptions?: Partial<PluginOptions>): Plugin {
           execPath: process.execPath,
         })
 
-        const proc = spawn(checker, ['--noEmit'], {
+        const checkerSuffix = platform() === 'win32' ? '.cmd' : ''
+        const proc = spawn(checker + checkerSuffix, ['--noEmit'], {
           cwd: process.cwd(),
           stdio: 'inherit',
           env: localEnv,


### PR DESCRIPTION
**Background:**
When npm packages install a `/.bin` executable on Windows they get created with a `.cmd` suffix, e.g. `tsc.cmd`

**Issue:**
This currently causes the plugin to fail on Windows when child_process tries to spawn `tsc`, since no such executable exists.

**Fix:**
Check for the current platform being Windows, and add the `.cmd` suffix when necessary.